### PR TITLE
Analyze findings for repo optimization

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,12 @@ import time
 import logging
 from pathlib import Path
 
+# Add backend to sys.path so tests can import local modules without PYTHONPATH
+import sys
+tests_dir = Path(__file__).resolve().parent
+backend_dir = tests_dir.parent
+sys.path.insert(0, str(backend_dir))
+
 # Set FALLBACK_TO_MEMORY before importing local_server for legacy tests
 os.environ.setdefault("FALLBACK_TO_MEMORY", "true")
 


### PR DESCRIPTION
# Pull Request Template

## Problem / Intent

This PR addresses the `ModuleNotFoundError: No module named 'local_server'` encountered when running backend tests. The problem arises because the Python interpreter cannot find modules from the `backend` root directory when tests are executed from `backend/tests` without `PYTHONPATH` being explicitly set.

This change ensures that `backend/tests` can correctly import modules from the `backend` root directory, making the test suite more robust and runnable across different environments (local, CI) without requiring specific environment variable configurations.

## Changes
- Added a `sys.path` shim to `backend/tests/conftest.py` to programmatically include the `backend` directory in the Python import path for tests.

## Budgets
- Files changed: 1
- LOC: +6

## Tests
- No new tests were added. This change fixes an import error that prevented existing backend tests from running.
- Commands to run tests: `pytest -q backend/tests`

## Docs
- No docs updated.
- [ ] Updated docs/CHANGELOG.md

## Risk & Rollback
- Potential impact: Very low. This change only affects the Python import path during test execution and is a common pattern for test setups.
- How to revert safely: Revert the commit or manually remove the 6 lines added to `backend/tests/conftest.py`.

## Verification Steps
1. Local commands to run:
   - Ensure `pytest` is installed in your environment.
   - From the project root, run: `pytest -q backend/tests`
2. CI job expectations:
   - The backend test suite should no longer fail due to `ModuleNotFoundError: No module named 'local_server'` and should proceed to execute tests.

---

*Closes #***

---
<a href="https://cursor.com/background-agent?bcId=bc-19148db9-a135-428e-97eb-d240f9d9ef43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19148db9-a135-428e-97eb-d240f9d9ef43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

