### PR TITLE
Phase 17.3: Secure Staging Deployment in Unified CI

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -223,3 +223,87 @@ jobs:
         with:
           name: backend-image
           path: backend-image.tar
+
+  deploy-staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      STAGING_S3_BUCKET: ${{ secrets.STAGING_S3_BUCKET }}
+      STAGING_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.STAGING_CLOUDFRONT_DISTRIBUTION_ID }}
+      STAGING_ECR_REPOSITORY: ${{ secrets.STAGING_ECR_REPOSITORY }}
+      STAGING_ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
+      STAGING_ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
+      STAGING_ECS_TASK_FAMILY: ${{ secrets.STAGING_ECS_TASK_FAMILY }}
+      STAGING_ECS_CONTAINER_NAME: ${{ secrets.STAGING_ECS_CONTAINER_NAME }}
+      STAGING_HEALTHCHECK_URL: ${{ secrets.STAGING_HEALTHCHECK_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend-dist
+
+      - name: Download backend image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-image
+          path: .
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Load and push backend image to ECR
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          docker load -i backend-image.tar
+          docker tag mobile-autoshop-backend:${{ github.sha }} "$REGISTRY/${STAGING_ECR_REPOSITORY}:${{ github.sha }}"
+          docker push "$REGISTRY/${STAGING_ECR_REPOSITORY}:${{ github.sha }}"
+
+      - name: Update ECS task definition and deploy
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          IMAGE_URI="$REGISTRY/${STAGING_ECR_REPOSITORY}:${{ github.sha }}"
+          # Fetch current task definition
+          aws ecs describe-task-definition --task-definition "$STAGING_ECS_TASK_FAMILY" --query 'taskDefinition' --output json > td.json
+          # Strip read-only fields and update image for target container name
+          jq --arg IMG "$IMAGE_URI" --arg NAME "$STAGING_ECS_CONTAINER_NAME" '
+            del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.deregisteredAt,.registeredBy)
+            | .containerDefinitions = (.containerDefinitions | map(if .name == $NAME then .image = $IMG | . else . end))
+          ' td.json > td-new.json
+          NEW_TD_ARN=$(aws ecs register-task-definition --cli-input-json file://td-new.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "New task definition: $NEW_TD_ARN"
+          aws ecs update-service --cluster "$STAGING_ECS_CLUSTER" --service "$STAGING_ECS_SERVICE" --task-definition "$NEW_TD_ARN" --force-new-deployment > /dev/null
+          echo "Waiting for service to stabilize..."
+          aws ecs wait services-stable --cluster "$STAGING_ECS_CLUSTER" --services "$STAGING_ECS_SERVICE"
+
+      - name: Deploy frontend to S3 (staging)
+        run: |
+          aws s3 sync frontend-dist "s3://${STAGING_S3_BUCKET}" --delete
+
+      - name: Invalidate CloudFront cache (staging)
+        if: env.STAGING_CLOUDFRONT_DISTRIBUTION_ID != ''
+        run: |
+          aws cloudfront create-invalidation --distribution-id "$STAGING_CLOUDFRONT_DISTRIBUTION_ID" --paths '/*'
+
+      - name: Post-deploy smoke test
+        run: |
+          echo "Pinging staging health endpoint: ${STAGING_HEALTHCHECK_URL}"
+          curl -f -sS "${STAGING_HEALTHCHECK_URL}" -o /dev/null

--- a/infrastructure/staging/README.md
+++ b/infrastructure/staging/README.md
@@ -1,0 +1,36 @@
+Staging Infrastructure (Terraform)
+
+This module provisions the minimal AWS resources required to support the Unified CI deploy-staging job:
+
+- ECR repository for backend images
+- ECS cluster, task definition (Fargate), and service fronted by an ALB
+- S3 bucket configured for static website hosting (frontend artifacts)
+- IAM roles: ECS task execution + app task role
+- GitHub Actions OIDC role for keyless deployments (optional; can also use access keys)
+
+Usage
+
+1) Initialize and apply:
+
+   - cd infrastructure/staging
+   - terraform init
+   - terraform apply -var="aws_region=us-east-1"
+
+2) Outputs to capture as GitHub repository secrets (Task 17.4):
+
+   - ecr_repository_name      -> STAGING_ECR_REPOSITORY
+   - ecs_cluster_name         -> STAGING_ECS_CLUSTER
+   - ecs_service_name         -> STAGING_ECS_SERVICE
+   - ecs_task_family          -> STAGING_ECS_TASK_FAMILY
+   - ecs_task_execution_role_arn (if needed for iam:PassRole)
+   - alb_dns_name             -> Use to build STAGING_HEALTHCHECK_URL (http://<alb_dns_name>/health)
+   - s3_bucket_name           -> STAGING_S3_BUCKET
+
+3) Container port is set to 3001 by default to match the backend. Update variables.tf if needed.
+
+Notes
+
+- The ECS task runs a placeholder http-echo container listening on port 3001 returning HTTP 200. The CI deploy job will replace the image with the real backend.
+- The ALB health check path is /health and the ELB DNS name is exposed as output for smoke tests.
+- The S3 bucket is configured for static website hosting for simplicity; a CloudFront distribution can be added later.
+- For GitHub OIDC: the trust policy is restricted to repo jaortiz123/Edgars-mobile-auto-shop. Adjust if the repository slug changes.

--- a/infrastructure/staging/alb.tf
+++ b/infrastructure/staging/alb.tf
@@ -1,0 +1,41 @@
+resource "aws_lb" "this" {
+  name               = "${local.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = data.aws_subnets.default_public.ids
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = "${local.name_prefix}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = data.aws_vpc.default.id
+  target_type = "ip" # required for Fargate
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    timeout             = 5
+    matcher             = "200-399"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+output "alb_dns_name" {
+  description = "ALB public DNS name"
+  value       = aws_lb.this.dns_name
+}

--- a/infrastructure/staging/ecr.tf
+++ b/infrastructure/staging/ecr.tf
@@ -1,0 +1,18 @@
+resource "aws_ecr_repository" "backend" {
+  name                 = local.ecr_repo_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+output "ecr_repository_name" {
+  description = "ECR repository name"
+  value       = aws_ecr_repository.backend.name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL (URI)"
+  value       = aws_ecr_repository.backend.repository_url
+}

--- a/infrastructure/staging/ecs.tf
+++ b/infrastructure/staging/ecs.tf
@@ -1,0 +1,87 @@
+resource "aws_ecs_cluster" "this" {
+  name = "${local.name_prefix}-cluster"
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = 14
+}
+
+locals {
+  placeholder_image = "hashicorp/http-echo:0.2.3"
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "${local.name_prefix}-task"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = local.placeholder_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+      # Make http-echo listen on our container port and return 200
+      entryPoint = ["/http-echo"]
+      command    = ["-listen", ":${var.container_port}", "-text", "ok"]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "backend" {
+  name            = "${local.name_prefix}-svc"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    assign_public_ip = true
+    subnets          = data.aws_subnets.default_public.ids
+    security_groups  = [aws_security_group.service.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "backend"
+    container_port   = var.container_port
+  }
+
+  depends_on = [aws_lb_listener.http]
+}
+
+output "ecs_cluster_name" {
+  value       = aws_ecs_cluster.this.name
+  description = "ECS cluster name"
+}
+
+output "ecs_service_name" {
+  value       = aws_ecs_service.backend.name
+  description = "ECS service name"
+}
+
+output "ecs_task_family" {
+  value       = aws_ecs_task_definition.backend.family
+  description = "ECS task definition family"
+}

--- a/infrastructure/staging/iam.tf
+++ b/infrastructure/staging/iam.tf
@@ -1,0 +1,141 @@
+data "aws_caller_identity" "current" {}
+
+# ECS task execution role (pull from ECR, write logs)
+resource "aws_iam_role" "ecs_task_execution" {
+  name               = "${local.name_prefix}-ecs-task-exec-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_trust.json
+}
+
+data "aws_iam_policy_document" "ecs_task_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_exec_managed" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Application task role (least-privilege; extend as needed)
+resource "aws_iam_role" "ecs_task" {
+  name               = "${local.name_prefix}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_trust.json
+}
+
+# GitHub OIDC Provider (for keyless CI deployments)
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# Role assumed by GitHub Actions to deploy to staging
+data "aws_iam_policy_document" "gha_assume" {
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    # Restrict to this repository
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:jaortiz123/Edgars-mobile-auto-shop:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "gha_staging_deployer" {
+  name               = "${local.name_prefix}-gha-staging-deployer"
+  assume_role_policy = data.aws_iam_policy_document.gha_assume.json
+}
+
+# Inline policy permitting ECR push, ECS register/update, S3 sync, CloudFront invalidation, and iam:PassRole for task exec role
+data "aws_iam_policy_document" "gha_permissions" {
+  statement {
+    sid     = "EcrAuth"
+    effect  = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:BatchGetImage",
+      "ecr:DescribeRepositories",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "EcsRegisterUpdate"
+    effect  = "Allow"
+    actions = [
+      "ecs:Describe*",
+      "ecs:RegisterTaskDefinition",
+      "ecs:UpdateService"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "IamPassRole"
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.ecs_task_execution.arn,
+      aws_iam_role.ecs_task.arn
+    ]
+  }
+
+  statement {
+    sid     = "S3Sync"
+    effect  = "Allow"
+    actions = ["s3:PutObject", "s3:DeleteObject", "s3:ListBucket", "s3:GetObject"]
+    resources = [
+      aws_s3_bucket.frontend.arn,
+      "${aws_s3_bucket.frontend.arn}/*"
+    ]
+  }
+
+  statement {
+    sid     = "CloudFrontInvalidate"
+    effect  = "Allow"
+    actions = ["cloudfront:CreateInvalidation", "cloudfront:GetDistribution", "cloudfront:GetInvalidation"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "gha_policy" {
+  name   = "${local.name_prefix}-gha-staging-deploy"
+  policy = data.aws_iam_policy_document.gha_permissions.json
+}
+
+resource "aws_iam_role_policy_attachment" "gha_attach" {
+  role       = aws_iam_role.gha_staging_deployer.name
+  policy_arn = aws_iam_policy.gha_policy.arn
+}
+
+output "gha_deployer_role_arn" {
+  description = "IAM role ARN to be assumed by GitHub Actions via OIDC"
+  value       = aws_iam_role.gha_staging_deployer.arn
+}
+
+output "ecs_task_execution_role_arn" {
+  description = "ECS task execution role ARN"
+  value       = aws_iam_role.ecs_task_execution.arn
+}

--- a/infrastructure/staging/networking.tf
+++ b/infrastructure/staging/networking.tf
@@ -1,0 +1,56 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default_public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+# Security group for ALB (HTTP 80 from anywhere)
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb-sg"
+  description = "ALB SG allowing HTTP inbound"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Security group for ECS tasks (allow app port from ALB)
+resource "aws_security_group" "service" {
+  name        = "${local.name_prefix}-svc-sg"
+  description = "Service SG allowing ALB→task traffic"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/infrastructure/staging/provider.tf
+++ b/infrastructure/staging/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infrastructure/staging/s3.tf
+++ b/infrastructure/staging/s3.tf
@@ -1,0 +1,55 @@
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${local.s3_bucket_base}-${random_id.bucket_suffix.hex}"
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket                  = aws_s3_bucket.frontend.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  index_document {
+    suffix = "index.html"
+  }
+  error_document {
+    key = "404.html"
+  }
+}
+
+data "aws_iam_policy_document" "public_read" {
+  statement {
+    sid     = "PublicReadGetObject"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      "${aws_s3_bucket.frontend.arn}/*"
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  policy = data.aws_iam_policy_document.public_read.json
+}
+
+output "s3_bucket_name" {
+  description = "Frontend S3 bucket name"
+  value       = aws_s3_bucket.frontend.bucket
+}
+
+output "s3_website_endpoint" {
+  description = "Frontend S3 static website endpoint"
+  value       = aws_s3_bucket.frontend.website_endpoint
+}

--- a/infrastructure/staging/variables.tf
+++ b/infrastructure/staging/variables.tf
@@ -1,0 +1,41 @@
+variable "aws_region" {
+  description = "AWS region to deploy staging infrastructure"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project/application name"
+  type        = string
+  default     = "mobile-auto-shop"
+}
+
+variable "environment" {
+  description = "Deployment environment name"
+  type        = string
+  default     = "staging"
+}
+
+variable "container_port" {
+  description = "Container port exposed by the backend service"
+  type        = number
+  default     = 3001
+}
+
+variable "desired_count" {
+  description = "Number of tasks to run in ECS service"
+  type        = number
+  default     = 1
+}
+
+variable "ecr_repository_name" {
+  description = "ECR repository name for backend image"
+  type        = string
+  default     = null
+}
+
+locals {
+  name_prefix        = "${var.project_name}-${var.environment}"
+  ecr_repo_name      = coalesce(var.ecr_repository_name, "${local.name_prefix}-backend")
+  s3_bucket_base     = replace(lower(local.name_prefix), "_", "-")
+}

--- a/infrastructure/staging/versions.tf
+++ b/infrastructure/staging/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}


### PR DESCRIPTION
Adds a deploy-staging job to .github/workflows/unified-ci.yml.

Behavior
- Runs only on push to main (not on PRs)
- Depends on all build/test jobs (needs: build)
- Authenticates with AWS using repository secrets (no hardcoded creds)
- Deploys backend: loads backend-image artifact, pushes to ECR, registers new ECS task revision, updates service, waits for stability
- Deploys frontend: downloads frontend-dist artifact, syncs to S3, invalidates CloudFront
- Verifies deployment via a smoke test (curl STAGING_HEALTHCHECK_URL); non-200 fails job

Configure these repository secrets before merge:
- AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
- STAGING_ECR_REPOSITORY, STAGING_ECS_CLUSTER, STAGING_ECS_SERVICE
- STAGING_ECS_TASK_FAMILY, STAGING_ECS_CONTAINER_NAME
- STAGING_S3_BUCKET, STAGING_CLOUDFRONT_DISTRIBUTION_ID (optional)
- STAGING_HEALTHCHECK_URL (e.g., https://staging.example.com/health)

This completes Task 17.3 DoD and sets the stage for serialized dev → staging → prod deployments.