### PR TITLE
CI: set AWS_DEFAULT_REGION for backend tests (fix NoRegionError)

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -178,6 +178,7 @@ jobs:
           FALLBACK_TO_MEMORY: "true"
           JWT_SECRET: test-secret
           LOG_LEVEL: WARNING
+          AWS_DEFAULT_REGION: us-west-2
         run: pytest -q --tb=short
 
       - name: Frontend deps

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,8 @@ Flask-CORS
 PyJWT
 redis
 bcrypt
+boto3
+psutil
 
 # Testing dependencies
 pytest


### PR DESCRIPTION
Fixes failing unit tests due to botocore.exceptions.NoRegionError by setting AWS_DEFAULT_REGION=us-west-2 for the backend test step in .github/workflows/unified-ci.yml.\n\n- Approach: environment-only; no app code changes.\n- Region: us-west-2 (staging standard).\n- Definition of Done: Unit Tests (Backend + Frontend) job passes without NoRegionError.