### PR TITLE
test(modals): Component coverage for AppointmentDetailModal, TemplateFormModal, AppointmentDrawer

### DIFF
--- a/frontend/src/tests/components/AppointmentDetailModal.real.test.tsx
+++ b/frontend/src/tests/components/AppointmentDetailModal.real.test.tsx
@@ -1,0 +1,362 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AppointmentDetailModal } from '@/components/admin/AppointmentDetailModal';
+
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  X: ({ className, ...props }: any) => <div data-testid="x-icon" className={className} {...props} />,
+  Phone: ({ className, ...props }: any) => <div data-testid="phone-icon" className={className} {...props} />,
+  MapPin: ({ className, ...props }: any) => <div data-testid="mappin-icon" className={className} {...props} />,
+  Clock: ({ className, ...props }: any) => <div data-testid="clock-icon" className={className} {...props} />,
+  Wrench: ({ className, ...props }: any) => <div data-testid="wrench-icon" className={className} {...props} />,
+  Car: ({ className, ...props }: any) => <div data-testid="car-icon" className={className} {...props} />,
+}));
+
+describe('AppointmentDetailModal', () => {
+  const mockAppointment = {
+    id: 'apt-123',
+    customer: 'John Smith',
+    vehicle: '2020 Honda Civic',
+    service: 'Oil Change',
+    timeSlot: '10:00 AM',
+    dateTime: new Date('2025-09-08T10:00:00'),
+    status: 'scheduled' as const,
+    phone: '555-0123',
+    address: '123 Main Street, Anytown, ST 12345'
+  };
+
+  const mockProps = {
+    appointment: mockAppointment,
+    isOpen: true,
+    onClose: vi.fn(),
+    onStartJob: vi.fn(),
+    onCompleteJob: vi.fn(),
+    onCallCustomer: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering Behavior', () => {
+    it('renders nothing when isOpen is false', () => {
+      const { container } = render(
+        <AppointmentDetailModal {...mockProps} isOpen={false} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders modal when isOpen is true', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+      expect(screen.getByText('📋 Appointment Details')).toBeInTheDocument();
+    });
+
+    it('renders all required appointment information', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      // Check customer info
+      expect(screen.getByText('John Smith')).toBeInTheDocument();
+      expect(screen.getByText('Customer')).toBeInTheDocument();
+
+      // Check vehicle info
+      expect(screen.getByText('2020 Honda Civic')).toBeInTheDocument();
+      expect(screen.getByText('Vehicle')).toBeInTheDocument();
+
+      // Check service info
+      expect(screen.getByText('Oil Change')).toBeInTheDocument();
+      expect(screen.getByText('Service Requested')).toBeInTheDocument();
+    });
+
+    it('renders customer initial in avatar', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+      expect(screen.getByText('J')).toBeInTheDocument(); // First letter of "John"
+    });
+
+    it('displays formatted date and time', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      // Check time format (10:00 AM)
+      expect(screen.getByText('10:00 AM')).toBeInTheDocument();
+
+      // Check date format (should be formatted)
+      expect(screen.getByText(/Monday, September 8, 2025/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Status Display and Styling', () => {
+    it('displays scheduled status with correct styling', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const statusBadge = screen.getByText('SCHEDULED');
+      expect(statusBadge).toBeInTheDocument();
+      expect(statusBadge).toHaveClass('bg-blue-100', 'text-blue-800', 'border-blue-200');
+    });
+
+    it('displays in-progress status with correct styling', () => {
+      const inProgressAppointment = { ...mockAppointment, status: 'in-progress' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={inProgressAppointment} />);
+
+      const statusBadge = screen.getByText('IN PROGRESS');
+      expect(statusBadge).toBeInTheDocument();
+      expect(statusBadge).toHaveClass('bg-yellow-100', 'text-yellow-800', 'border-yellow-200');
+    });
+
+    it('displays completed status with correct styling', () => {
+      const completedAppointment = { ...mockAppointment, status: 'completed' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={completedAppointment} />);
+
+      const statusBadge = screen.getByText('COMPLETED');
+      expect(statusBadge).toBeInTheDocument();
+      expect(statusBadge).toHaveClass('bg-green-100', 'text-green-800', 'border-green-200');
+    });
+
+    it('displays canceled status with correct styling', () => {
+      const canceledAppointment = { ...mockAppointment, status: 'canceled' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={canceledAppointment} />);
+
+      const statusBadge = screen.getByText('CANCELED');
+      expect(statusBadge).toBeInTheDocument();
+      expect(statusBadge).toHaveClass('bg-gray-100', 'text-gray-800', 'border-gray-200');
+    });
+  });
+
+  describe('Optional Fields', () => {
+    it('renders phone number section when phone is provided', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      expect(screen.getByText('555-0123')).toBeInTheDocument();
+      expect(screen.getByText('Phone Number')).toBeInTheDocument();
+      expect(screen.getByText('📞 Call')).toBeInTheDocument();
+    });
+
+    it('does not render phone section when phone is not provided', () => {
+      const appointmentWithoutPhone = { ...mockAppointment, phone: undefined };
+      render(<AppointmentDetailModal {...mockProps} appointment={appointmentWithoutPhone} />);
+
+      expect(screen.queryByText('Phone Number')).not.toBeInTheDocument();
+      expect(screen.queryByText('📞 Call')).not.toBeInTheDocument();
+    });
+
+    it('renders address section when address is provided', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      expect(screen.getByText('123 Main Street, Anytown, ST 12345')).toBeInTheDocument();
+      expect(screen.getByText('Service Address')).toBeInTheDocument();
+    });
+
+    it('does not render address section when address is not provided', () => {
+      const appointmentWithoutAddress = { ...mockAppointment, address: undefined };
+      render(<AppointmentDetailModal {...mockProps} appointment={appointmentWithoutAddress} />);
+
+      expect(screen.queryByText('Service Address')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Action Buttons', () => {
+    it('shows start job button for scheduled appointments', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const startButton = screen.getByRole('button', { name: /start this job/i });
+      expect(startButton).toBeInTheDocument();
+      expect(startButton.tagName).toBe('BUTTON');
+    });
+
+    it('shows complete job button for in-progress appointments', () => {
+      const inProgressAppointment = { ...mockAppointment, status: 'in-progress' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={inProgressAppointment} />);
+
+      const completeButton = screen.getByRole('button', { name: /mark as complete/i });
+      expect(completeButton).toBeInTheDocument();
+      expect(completeButton.tagName).toBe('BUTTON');
+    });
+
+    it('does not show action buttons for completed appointments', () => {
+      const completedAppointment = { ...mockAppointment, status: 'completed' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={completedAppointment} />);
+
+      expect(screen.queryByText('🔧 Start This Job')).not.toBeInTheDocument();
+      expect(screen.queryByText('✅ Mark as Complete')).not.toBeInTheDocument();
+    });
+
+    it('does not show action buttons for canceled appointments', () => {
+      const canceledAppointment = { ...mockAppointment, status: 'canceled' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={canceledAppointment} />);
+
+      expect(screen.queryByText('🔧 Start This Job')).not.toBeInTheDocument();
+      expect(screen.queryByText('✅ Mark as Complete')).not.toBeInTheDocument();
+    });
+
+    it('always shows close button', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      // Should have two close buttons: X icon and "Close" text button
+      expect(screen.getAllByText('Close')).toHaveLength(1);
+      expect(screen.getByLabelText('Close modal')).toBeInTheDocument();
+    });
+  });
+
+  describe('Event Handling', () => {
+    it('calls onClose when X button is clicked', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const closeButton = screen.getByLabelText('Close modal');
+      fireEvent.click(closeButton);
+
+      expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Close button is clicked', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const closeButton = screen.getByText('Close');
+      fireEvent.click(closeButton);
+
+      expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onStartJob when start job button is clicked', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const startButton = screen.getByText('🔧 Start This Job');
+      fireEvent.click(startButton);
+
+      expect(mockProps.onStartJob).toHaveBeenCalledWith('apt-123');
+    });
+
+    it('calls onCompleteJob when complete job button is clicked', () => {
+      const inProgressAppointment = { ...mockAppointment, status: 'in-progress' as const };
+      render(<AppointmentDetailModal {...mockProps} appointment={inProgressAppointment} />);
+
+      const completeButton = screen.getByText('✅ Mark as Complete');
+      fireEvent.click(completeButton);
+
+      expect(mockProps.onCompleteJob).toHaveBeenCalledWith('apt-123');
+    });
+
+    it('calls onCallCustomer when call button is clicked', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const callButton = screen.getByText('📞 Call');
+      fireEvent.click(callButton);
+
+      expect(mockProps.onCallCustomer).toHaveBeenCalledWith('555-0123');
+    });
+
+    it('does not call onStartJob when handler is not provided', () => {
+      const propsWithoutStartJob = { ...mockProps, onStartJob: undefined };
+      render(<AppointmentDetailModal {...propsWithoutStartJob} />);
+
+      const startButton = screen.getByText('🔧 Start This Job');
+      fireEvent.click(startButton);
+
+      // Should not throw error
+      expect(mockProps.onStartJob).not.toHaveBeenCalled();
+    });
+
+    it('does not call onCompleteJob when handler is not provided', () => {
+      const inProgressAppointment = { ...mockAppointment, status: 'in-progress' as const };
+      const propsWithoutCompleteJob = { ...mockProps, appointment: inProgressAppointment, onCompleteJob: undefined };
+      render(<AppointmentDetailModal {...propsWithoutCompleteJob} />);
+
+      const completeButton = screen.getByText('✅ Mark as Complete');
+      fireEvent.click(completeButton);
+
+      // Should not throw error
+      expect(mockProps.onCompleteJob).not.toHaveBeenCalled();
+    });
+
+    it('does not call onCallCustomer when handler is not provided', () => {
+      const propsWithoutCallCustomer = { ...mockProps, onCallCustomer: undefined };
+      render(<AppointmentDetailModal {...propsWithoutCallCustomer} />);
+
+      const callButton = screen.getByText('📞 Call');
+      fireEvent.click(callButton);
+
+      // Should not throw error
+      expect(mockProps.onCallCustomer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Utility Functions', () => {
+    it('formats time correctly for different times', () => {
+      const morningAppointment = { ...mockAppointment, dateTime: new Date('2025-09-08T09:30:00') };
+      render(<AppointmentDetailModal {...mockProps} appointment={morningAppointment} />);
+      expect(screen.getByText('9:30 AM')).toBeInTheDocument();
+
+      // Test afternoon time
+      const afternoonAppointment = { ...mockAppointment, dateTime: new Date('2025-09-08T14:45:00') };
+      const { rerender } = render(<AppointmentDetailModal {...mockProps} appointment={afternoonAppointment} />);
+      expect(screen.getByText('2:45 PM')).toBeInTheDocument();
+    });
+
+    it('formats date correctly for different dates', () => {
+      const differentDate = { ...mockAppointment, dateTime: new Date('2025-12-25T10:00:00') };
+      render(<AppointmentDetailModal {...mockProps} appointment={differentDate} />);
+      expect(screen.getByText(/Thursday, December 25, 2025/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Icon Rendering', () => {
+    it('renders all required icons', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      expect(screen.getByTestId('x-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('clock-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('car-icon')).toBeInTheDocument();
+      expect(screen.getAllByTestId('wrench-icon')).toHaveLength(2); // One in service section, one in button
+      expect(screen.getByTestId('phone-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('mappin-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has proper aria labels on interactive elements', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      expect(screen.getByLabelText('Close modal')).toBeInTheDocument();
+    });
+
+    it('uses semantic button elements for interactions', () => {
+      render(<AppointmentDetailModal {...mockProps} />);
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBeGreaterThan(0);
+
+      // Check specific buttons
+      expect(screen.getByRole('button', { name: /close modal/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /start this job/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /call/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles customer names with single character', () => {
+      const singleCharCustomer = { ...mockAppointment, customer: 'A' };
+      render(<AppointmentDetailModal {...mockProps} appointment={singleCharCustomer} />);
+
+      expect(screen.getAllByText('A')).toHaveLength(2); // Both name and initial
+    });
+
+    it('handles empty customer name gracefully', () => {
+      const emptyCustomer = { ...mockAppointment, customer: '' };
+      render(<AppointmentDetailModal {...mockProps} appointment={emptyCustomer} />);
+
+      // Should still render without errors
+      expect(screen.getByText('Customer')).toBeInTheDocument();
+    });
+
+    it('handles missing optional callbacks gracefully', () => {
+      const minimalProps = {
+        appointment: mockAppointment,
+        isOpen: true,
+        onClose: vi.fn()
+      };
+
+      render(<AppointmentDetailModal {...minimalProps} />);
+
+      // Should render without errors
+      expect(screen.getByText('📋 Appointment Details')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/AppointmentDrawer.invoice.test.tsx
+++ b/frontend/src/tests/components/AppointmentDrawer.invoice.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock router navigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+// Mock api lib minimal endpoints used by drawer bundle
+vi.mock('@/lib/api', async () => {
+  const actual = (await vi.importActual('@/lib/api')) as Record<string, unknown>
+  return {
+    ...actual,
+    getDrawer: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-9', status: 'COMPLETED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: []
+    }),
+    getAppointmentServices: vi.fn().mockResolvedValue([]),
+    getAppointment: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-9', status: 'COMPLETED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: []
+    }),
+  }
+})
+
+// Mock invoice API
+vi.mock('@/services/apiService', () => ({
+  generateInvoice: vi.fn(),
+}))
+// Spyable toast mock (define before importing component)
+const toastError = vi.fn()
+vi.mock('@/components/ui/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ success: vi.fn(), error: toastError, push: vi.fn() })
+}))
+
+import AppointmentDrawer from '@/components/admin/AppointmentDrawer'
+import { AccessibilityProvider } from '@/contexts/AccessibilityProvider'
+import { generateInvoice } from '@/services/apiService'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+function wrap(ui: React.ReactNode) {
+  // Ensure bundle query is enabled
+  ;(window as any).__APPT_DRAWER_BUNDLE__ = true
+  const qc = new QueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AccessibilityProvider>{ui}</AccessibilityProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppointmentDrawer invoice generation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // default success payload
+    vi.mocked(generateInvoice).mockResolvedValue({ invoice: { id: 'inv-1', status: 'DRAFT', total_cents: 0, amount_due_cents: 0, amount_paid_cents: 0, subtotal_cents: 0, tax_cents: 0 } })
+  })
+
+  it('shows Generate Invoice button for COMPLETED appointment and calls API on click', async () => {
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-9" />))
+
+    // Drawer visible
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    // Button should be visible because status is COMPLETED and no invoice id
+    const btn = await screen.findByTestId('generate-invoice-btn')
+    expect(btn).toBeEnabled()
+
+    await userEvent.click(btn)
+
+    await waitFor(() => expect(generateInvoice).toHaveBeenCalledWith('apt-9'))
+  })
+
+  it('handles failure by re-enabling button (no crash)', async () => {
+    vi.mocked(generateInvoice).mockRejectedValueOnce(new Error('Failed to create invoice'))
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-9" />))
+
+    const btn = await screen.findByTestId('generate-invoice-btn')
+    await userEvent.click(btn)
+
+  // Button becomes enabled again after failure
+  await waitFor(() => expect(btn).toBeEnabled())
+  })
+})

--- a/frontend/src/tests/components/AppointmentDrawer.overview.test.tsx
+++ b/frontend/src/tests/components/AppointmentDrawer.overview.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock router navigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+// Spyable toast mock
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('@/components/ui/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ success: toastSuccess, error: toastError, push: vi.fn() })
+}))
+
+// Mock technicians hook so we can assign one
+vi.mock('@/hooks/useTechnicians', () => ({
+  useTechnicians: () => ({ data: [{ id: 't1', initials: 'AB', name: 'Alice Brown' }], isLoading: false })
+}))
+
+// Mock api lib used by drawer
+vi.mock('@/lib/api', async () => {
+  const actual = (await vi.importActual('@/lib/api')) as Record<string, unknown>
+  return {
+    ...actual,
+    handleApiError: (e: unknown, fallback?: string) => (e instanceof Error ? e.message : (fallback || 'Error')),
+    getDrawer: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-ov-1', status: 'SCHEDULED', start: '2025-01-01T10:00:00.000Z', end: '2025-01-01T11:00:00.000Z', tech_id: null },
+      customer: { id: 'c-ov-1', name: 'Jane' },
+      vehicle: { id: 'v-ov-1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: [],
+    }),
+  // Force Overview fallback (rich edit form disabled in these tests)
+  getAppointment: vi.fn().mockRejectedValue(new Error('rich disabled for overview tests')),
+    getAppointmentServices: vi.fn().mockResolvedValue([]),
+    patchAppointment: vi.fn().mockResolvedValue({ ok: true }),
+    rescheduleAppointment: vi.fn().mockResolvedValue({ ok: true }),
+  }
+})
+
+import AppointmentDrawer from '@/components/admin/AppointmentDrawer'
+import { AccessibilityProvider } from '@/contexts/AccessibilityProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as api from '@/lib/api'
+
+function wrap(ui: React.ReactNode) {
+  ;(window as any).__APPT_DRAWER_BUNDLE__ = true
+  const qc = new QueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AccessibilityProvider>{ui}</AccessibilityProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppointmentDrawer - Overview interactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves vehicle details with uppercased plate', async () => {
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-ov-1" />))
+
+    // Plate input -> uppercase should be applied on change
+    const plate = await screen.findByLabelText('Plate')
+    await userEvent.clear(plate)
+    await userEvent.type(plate, 'abc123')
+
+    // Model select is within the vehicle block; find the nearest container and the Save button inside it
+    const modelSelect = await screen.findByLabelText('Model')
+    const vehicleBlock = modelSelect.closest('div')!.parentElement as HTMLElement // div.col-span-1 flex gap-2 -> parent is grid area
+    const saveBtn = within(vehicleBlock).getByRole('button', { name: /^save$/i })
+    await userEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(api.patchAppointment).toHaveBeenCalledWith('apt-ov-1', expect.objectContaining({ license_plate: 'ABC123' }))
+      expect(toastSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('saves meta details (address and notes)', async () => {
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-ov-1" />))
+
+    const addr = await screen.findByLabelText(/service address/i)
+    await userEvent.clear(addr)
+    await userEvent.type(addr, '123 Elm St')
+
+    const notes = await screen.findByLabelText(/notes/i)
+    await userEvent.clear(notes)
+    await userEvent.type(notes, 'Please handle with care')
+
+    // Click the first "Save" next to address field
+    const metaRow = addr.closest('div')!.parentElement as HTMLElement
+    const saveBtn = within(metaRow).getByRole('button', { name: /^save$/i })
+    await userEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(api.patchAppointment).toHaveBeenCalledWith('apt-ov-1', expect.objectContaining({ location_address: '123 Elm St', notes: 'Please handle with care' }))
+      expect(toastSuccess).toHaveBeenCalledWith('Details saved')
+    })
+  })
+
+  it('assigns a technician and shows toast', async () => {
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-ov-1" />))
+
+    const techSelect = await screen.findByLabelText('Technician')
+    await userEvent.selectOptions(techSelect, 't1')
+
+    await waitFor(() => {
+      expect(api.patchAppointment).toHaveBeenCalledWith('apt-ov-1', { tech_id: 't1' })
+      expect(toastSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('shows error toast when reschedule fails and re-enables Save', async () => {
+    vi.mocked(api.rescheduleAppointment).mockRejectedValueOnce(new Error('Nope'))
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-ov-1" />))
+
+    const reschedBtn = await screen.findByRole('button', { name: /reschedule/i })
+    await userEvent.click(reschedBtn)
+
+    const input = await screen.findByLabelText(/new date and time/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, '2025-09-08T10:00')
+
+  // Scope to the reschedule modal to avoid matching the Overview "Save" buttons
+  const modalHeading = await screen.findByRole('heading', { name: /reschedule appointment/i })
+  const modalContainer = modalHeading.closest('div') as HTMLElement
+  const save = within(modalContainer).getByRole('button', { name: /^save$/i })
+    await userEvent.click(save)
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled()
+      expect(save).toBeEnabled()
+    })
+  })
+})

--- a/frontend/src/tests/components/AppointmentDrawer.richerror.test.tsx
+++ b/frontend/src/tests/components/AppointmentDrawer.richerror.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mock router navigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+// Minimal toast mock
+vi.mock('@/components/ui/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ success: vi.fn(), error: vi.fn(), push: vi.fn() })
+}))
+
+// Do not mock the bundle hook; let drawer fetch run
+vi.mock('@/lib/api', async () => {
+  const actual = (await vi.importActual('@/lib/api')) as Record<string, unknown>
+  return {
+    ...actual,
+    handleApiError: (e: unknown, fallback?: string) => (e instanceof Error ? e.message : (fallback || 'Error')),
+    getDrawer: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-re-1', status: 'SCHEDULED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: [],
+    }),
+    getAppointment: vi.fn().mockRejectedValue(new Error('rich fetch failed')),
+    getAppointmentServices: vi.fn().mockResolvedValue([]),
+  }
+})
+
+import AppointmentDrawer from '@/components/admin/AppointmentDrawer'
+import { AccessibilityProvider } from '@/contexts/AccessibilityProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+function wrap(ui: React.ReactNode) {
+  ;(window as any).__APPT_DRAWER_BUNDLE__ = true
+  const qc = new QueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AccessibilityProvider>{ui}</AccessibilityProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppointmentDrawer - rich fetch error banner', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders error banner when rich fetch fails but legacy drawer succeeds', async () => {
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-re-1" />))
+
+    // Drawer is open
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    // Error banner shows the rich error message (generic text)
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/failed to load appointment/i)
+  })
+})

--- a/frontend/src/tests/components/AppointmentDrawer.services.test.tsx
+++ b/frontend/src/tests/components/AppointmentDrawer.services.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock router navigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+// Spyable toast mock
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('@/components/ui/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ success: toastSuccess, error: toastError, push: vi.fn() })
+}))
+
+// Mock service catalog search to provide deterministic results
+vi.mock('@/hooks/useServiceCatalogSearch', () => ({
+  useServiceCatalogSearch: () => ({
+    // Return one hit when any non-empty term is provided
+    search: (term: string) => term ? [
+      { id: 'op-1', name: 'Brake Pads', system: 'Safety', defaultHours: 2, defaultLaborHours: undefined }
+    ] : [],
+    all: [
+      { id: 'op-1', name: 'Brake Pads', system: 'Safety', defaultHours: 2 }
+    ] as any,
+  }),
+}))
+
+// Note: we do NOT mock useAppointmentBundle. We enable the feature flag and let
+// the hook call our mocked api.getDrawer/getAppointmentServices via TanStack Query.
+
+// Mock core API functions used by save/reschedule flows
+vi.mock('@/lib/api', async () => {
+  const actual = (await vi.importActual('@/lib/api')) as Record<string, unknown>
+  const apiMocks = {
+    ...actual,
+    handleApiError: (e: unknown, fallback?: string) => (e instanceof Error ? e.message : (fallback || 'Error')),
+    getDrawer: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-201', status: 'SCHEDULED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: [],
+    }),
+    getAppointment: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-201', status: 'SCHEDULED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: [],
+    }),
+    getAppointmentServices: vi.fn().mockResolvedValue([]),
+    createAppointmentService: vi.fn().mockResolvedValue({ service: { id: 'svc-new', estimated_price: 240 }, appointment_total: 240 }),
+    updateAppointmentService: vi.fn().mockResolvedValue({ ok: true }),
+    deleteAppointmentService: vi.fn().mockResolvedValue({ ok: true }),
+    rescheduleAppointment: vi.fn().mockResolvedValue({ ok: true }),
+    patchAppointment: vi.fn().mockResolvedValue({ ok: true }),
+  }
+  return apiMocks
+})
+
+import AppointmentDrawer from '@/components/admin/AppointmentDrawer'
+import { AccessibilityProvider } from '@/contexts/AccessibilityProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as api from '@/lib/api'
+// We purposely avoid importing/mocking the bundle hook
+
+function wrap(ui: React.ReactNode) {
+  // Enable bundle code paths
+  ;(window as any).__APPT_DRAWER_BUNDLE__ = true
+  const qc = new QueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AccessibilityProvider>{ui}</AccessibilityProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppointmentDrawer - Services and Reschedule flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('stages a catalog service and saves it (create path)', async () => {
+    // For create flow, first bundle fetch returns no services, after save/refetch it returns one
+    vi.mocked(api.getAppointmentServices)
+      .mockResolvedValueOnce([]) // initial bundle
+      .mockResolvedValueOnce([ { id: 'svc-created-1', name: 'Brake Pads', estimated_price: 240, estimated_hours: 2 } ] as any) // after save
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-201" />))
+
+    // Switch to Services tab
+    const servicesTab = await screen.findByRole('tab', { name: /services/i })
+    await userEvent.click(servicesTab)
+
+    // Empty state with catalog search should appear
+    const search = await screen.findByTestId('svc-catalog-search')
+    await userEvent.type(search, 'brake')
+
+    const results = await screen.findByTestId('svc-catalog-results')
+    const item = within(results).getByTestId('catalog-result-op-1')
+    await userEvent.click(item)
+
+    // One staged service should now exist in the hidden metadata on list
+    const list = await screen.findByTestId('services-list')
+    expect(list.getAttribute('data-added-temp-count')).toBe('1')
+
+  // Save should call createAppointmentService and show success toast
+    const saveBtn = await screen.findByTestId('drawer-save')
+    expect(saveBtn).toBeEnabled()
+    await userEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(api.createAppointmentService).toHaveBeenCalledTimes(1)
+      expect(toastSuccess).toHaveBeenCalled()
+    })
+
+    // Button becomes disabled after refetch (no pending changes)
+    await waitFor(() => expect(saveBtn).toBeDisabled())
+  })
+
+  it('edits an existing service and saves (update path)', async () => {
+    // Initial bundle has one persisted service, and refetch returns it again
+    vi.mocked(api.getAppointmentServices)
+      .mockResolvedValueOnce([ { id: 'svc-9', name: 'Oil Change', estimated_price: 100, estimated_hours: 1 } ] as any)
+      .mockResolvedValueOnce([ { id: 'svc-9', name: 'Oil Change', estimated_price: 150, estimated_hours: 1 } ] as any)
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-201" />))
+
+    const servicesTab = await screen.findByRole('tab', { name: /services/i })
+    await userEvent.click(servicesTab)
+
+    // Toggle edit and change price to 150
+    const editBtn = await screen.findByTestId('edit-service-svc-9')
+    await userEvent.click(editBtn)
+
+    const priceCell = await screen.findByTestId('service-price-svc-9')
+    const priceInput = within(priceCell).getByLabelText('Price') as HTMLInputElement
+    await userEvent.clear(priceInput)
+    await userEvent.type(priceInput, '150')
+
+    // Save -> should call updateAppointmentService
+    const saveBtn = await screen.findByTestId('drawer-save')
+    await userEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(api.updateAppointmentService).toHaveBeenCalledWith('apt-201', 'svc-9', expect.objectContaining({ estimated_price: 150 }))
+      expect(toastSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('marks a service for deletion and saves (delete path)', async () => {
+    vi.mocked(api.getAppointmentServices)
+      .mockResolvedValueOnce([ { id: 'svc-8', name: 'Rotate Tires', estimated_price: 60, estimated_hours: 0.5 } ] as any)
+      .mockResolvedValueOnce([] as any)
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-201" />))
+
+    const servicesTab = await screen.findByRole('tab', { name: /services/i })
+    await userEvent.click(servicesTab)
+
+    const delBtn = await screen.findByTestId('delete-service-svc-8')
+    await userEvent.click(delBtn)
+
+    const saveBtn = await screen.findByTestId('drawer-save')
+    await userEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(api.deleteAppointmentService).toHaveBeenCalledWith('apt-201', 'svc-8')
+      expect(toastSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('reschedules an appointment via modal', async () => {
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-201" />))
+
+    const reschedBtn = await screen.findByRole('button', { name: /reschedule/i })
+    await userEvent.click(reschedBtn)
+
+    const input = await screen.findByLabelText(/new date and time/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, '2025-09-08T10:00')
+
+    const save = await screen.findByRole('button', { name: /^save$/i })
+    await userEvent.click(save)
+
+    await waitFor(() => expect(api.rescheduleAppointment).toHaveBeenCalledTimes(1))
+  })
+})

--- a/frontend/src/tests/components/AppointmentDrawer.states.test.tsx
+++ b/frontend/src/tests/components/AppointmentDrawer.states.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock router navigate to avoid real navigation
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+// Spyable toast mock
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('@/components/ui/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ success: toastSuccess, error: toastError, push: vi.fn() })
+}))
+
+// Mock service catalog search to ensure predictable search results
+vi.mock('@/hooks/useServiceCatalogSearch', () => ({
+  useServiceCatalogSearch: () => ({
+    search: (term: string) => (term ? [ { id: 'op-1', name: 'Brake Pads', system: 'Safety', defaultHours: 2 } ] : []),
+    all: [ { id: 'op-1', name: 'Brake Pads', system: 'Safety', defaultHours: 2 } ] as any,
+  }),
+}))
+
+// We'll mock the bundle hook per-test for state coverage
+const mockUseAppointmentBundle = vi.fn()
+vi.mock('@/hooks/useAppointmentBundle', () => ({
+  useAppointmentBundle: (...args: any[]) => mockUseAppointmentBundle(...args),
+}))
+
+// Mock core API minimal endpoints used by effects; override per test where needed
+vi.mock('@/lib/api', async () => {
+  const actual = (await vi.importActual('@/lib/api')) as Record<string, unknown>
+  return {
+    ...actual,
+    handleApiError: (e: unknown, fallback?: string) => (e instanceof Error ? e.message : (fallback || 'Error')),
+    getDrawer: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-300', status: 'SCHEDULED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: [],
+    }),
+    getAppointment: vi.fn().mockResolvedValue({
+      appointment: { id: 'apt-300', status: 'SCHEDULED' },
+      customer: { id: 'c1', name: 'Jane' },
+      vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      services: [],
+    }),
+    getAppointmentServices: vi.fn().mockResolvedValue([]),
+    createAppointmentService: vi.fn().mockResolvedValue({ ok: true }),
+  }
+})
+
+import AppointmentDrawer from '@/components/admin/AppointmentDrawer'
+import { AccessibilityProvider } from '@/contexts/AccessibilityProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as api from '@/lib/api'
+
+function wrap(ui: React.ReactNode) {
+  // Enable bundle paths by default
+  ;(window as any).__APPT_DRAWER_BUNDLE__ = true
+  const qc = new QueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AccessibilityProvider>{ui}</AccessibilityProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppointmentDrawer - state coverage (loading, error, success)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading overlay while bundle is loading', async () => {
+    mockUseAppointmentBundle.mockReturnValue({ isLoading: true, data: undefined, refetch: vi.fn() })
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-300" />))
+
+    const status = await screen.findByRole('status')
+    expect(status).toHaveTextContent(/loading appointment/i)
+  })
+
+  it('shows error banner when legacy drawer fetch fails', async () => {
+    // Not loading
+    mockUseAppointmentBundle.mockReturnValue({ isLoading: false, data: undefined, refetch: vi.fn() })
+    // Force legacy drawer to fail, rich succeeds or not — banner should render
+    vi.mocked(api.getDrawer).mockRejectedValueOnce(new Error('DB down'))
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-300" />))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/failed to load appointment/i)
+  })
+
+  it('renders success state with tabs and allows staging+removing a service (state toggles)', async () => {
+    // Success bundle returns empty services; not loading
+    mockUseAppointmentBundle.mockReturnValue({
+      isLoading: false,
+      data: {
+        appointment: { id: 'apt-300', status: 'SCHEDULED' },
+        services: [],
+        customer: { id: 'c1', name: 'Jane' },
+        vehicle: { id: 'v1', year: 2020, make: 'Honda', model: 'Civic', vin: '' },
+      },
+      refetch: vi.fn(),
+    })
+
+    render(wrap(<AppointmentDrawer open onClose={() => {}} id="apt-300" />))
+
+    // Drawer visible with tabs
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    const servicesTab = await screen.findByRole('tab', { name: /services/i })
+    await userEvent.click(servicesTab)
+
+    // Empty state search: stage one service from catalog
+    const search = await screen.findByTestId('svc-catalog-search')
+    await userEvent.type(search, 'brake')
+    const results = await screen.findByTestId('svc-catalog-results')
+    const first = within(results).getByTestId('catalog-result-op-1')
+    await userEvent.click(first)
+
+  // Wait for at least one service item to appear in the rendered list
+  const firstItem = await screen.findByTestId(/service-item-/i)
+  expect(firstItem).toBeInTheDocument()
+  const list = await screen.findByTestId('services-list')
+  expect(list.getAttribute('data-added-temp-count')).toBe('1')
+
+    // Save button becomes enabled due to dirty working state
+    const saveBtn = await screen.findByTestId('drawer-save')
+    expect(saveBtn).toBeEnabled()
+
+    // Remove staged service using the visible Remove button within staged item
+    const stagedItem = within(await screen.findByTestId('services-list')).getAllByTestId(/service-item-/i)[0]
+  const removeBtn = within(stagedItem).getByRole('button', { name: /(remove|delete)/i })
+    await userEvent.click(removeBtn)
+
+    // Save disabled again (no pending changes) and metadata back to zero
+    await waitFor(async () => {
+      const freshList = await screen.findByTestId('services-list')
+      expect(freshList.getAttribute('data-added-temp-count')).toBe('0')
+      expect(saveBtn).toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/tests/components/TemplateFormModal.comprehensive.test.tsx
+++ b/frontend/src/tests/components/TemplateFormModal.comprehensive.test.tsx
@@ -1,0 +1,685 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TemplateFormModal } from '@/components/admin/TemplateFormModal';
+
+// Mock the API functions
+vi.mock('@/lib/api', () => ({
+  createMessageTemplate: vi.fn(),
+  updateMessageTemplate: vi.fn(),
+}));
+
+// Mock the message templates utility
+vi.mock('@/lib/messageTemplates', () => ({
+  extractTemplateVariables: vi.fn(),
+}));
+
+import { createMessageTemplate, updateMessageTemplate } from '@/lib/api';
+import { extractTemplateVariables } from '@/lib/messageTemplates';
+
+describe('TemplateFormModal', () => {
+  const mockOnClose = vi.fn();
+  const mockOnSaved = vi.fn();
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (extractTemplateVariables as any).mockReturnValue(['customer.name', 'vehicle.make']);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    mode: 'create' as const,
+    open: true,
+    onClose: mockOnClose,
+    onSaved: mockOnSaved,
+  };
+
+  describe('Rendering and Initial State', () => {
+    it('should render create mode correctly', () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      expect(screen.getByText('Create Template')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByLabelText(/slug/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/label/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/channel/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/body/i)).toBeInTheDocument();
+    });
+
+    it('should render edit mode correctly', () => {
+      const initial = {
+        id: 'test-id-1',
+        slug: 'test-template',
+        label: 'Test Template',
+        channel: 'sms' as const,
+        category: 'Test Category',
+        body: 'Hello {{customer.name}}',
+        variables: ['customer.name'],
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      };
+
+      render(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} />);
+
+      expect(screen.getByText('Edit Template')).toBeInTheDocument();
+      expect(screen.queryByLabelText(/slug/i)).not.toBeInTheDocument(); // Slug not editable in edit mode
+
+      // Use more specific queries to avoid ambiguity
+      const labelInput = screen.getByLabelText(/label/i) as HTMLInputElement;
+      const categoryInput = screen.getByLabelText(/category/i) as HTMLInputElement;
+      const bodyInput = screen.getByLabelText(/body/i) as HTMLTextAreaElement;
+
+      expect(labelInput.value).toBe('Test Template');
+      expect(categoryInput.value).toBe('Test Category');
+      expect(bodyInput.value).toBe('Hello {{customer.name}}');
+    });
+
+    it('should not render when closed', () => {
+      render(<TemplateFormModal {...defaultProps} open={false} />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should show default values in create mode', () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      expect(screen.getByLabelText(/slug/i)).toHaveValue('');
+      expect(screen.getByLabelText(/label/i)).toHaveValue('');
+      expect(screen.getByLabelText(/channel/i)).toHaveValue('sms');
+      expect(screen.getByLabelText(/category/i)).toHaveValue('');
+      expect(screen.getByLabelText(/body/i)).toHaveValue('');
+    });
+
+    it('should show active checkbox only in edit mode', () => {
+      const { rerender } = render(<TemplateFormModal {...defaultProps} mode="create" />);
+      expect(screen.queryByLabelText('Active')).not.toBeInTheDocument();
+
+      const initial = {
+        id: 'test-id-2',
+        slug: 'test-template',
+        label: 'Test Template',
+        channel: 'sms' as const,
+        category: 'Test Category',
+        body: 'Hello {{customer.name}}',
+        variables: ['customer.name'],
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      };
+
+      rerender(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} />);
+      expect(screen.getByLabelText('Active')).toBeInTheDocument();
+      expect(screen.getByLabelText('Active')).toBeChecked();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    it('should update form fields correctly', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      const labelInput = screen.getByLabelText(/label/i);
+      const categoryInput = screen.getByLabelText(/category/i);
+      const bodyInput = screen.getByLabelText(/body/i);
+
+      // Clear existing values first
+      await user.clear(slugInput);
+      await user.clear(labelInput);
+      await user.clear(categoryInput);
+      await user.clear(bodyInput);
+
+      await user.type(slugInput, 'test_slug');
+      await user.type(labelInput, 'Test Label');
+      await user.type(categoryInput, 'Test Category');
+
+      // Use fireEvent.change for complex text with special characters
+      fireEvent.change(bodyInput, { target: { value: 'Test body with {{variable}}' } });
+
+      expect(slugInput).toHaveValue('test_slug');
+      expect(labelInput).toHaveValue('Test Label');
+      expect(categoryInput).toHaveValue('Test Category');
+      expect(bodyInput).toHaveValue('Test body with {{variable}}');
+    });
+
+    it('should change channel selection', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const channelSelect = screen.getByLabelText(/channel/i);
+      expect(channelSelect).toHaveValue('sms');
+
+      await user.selectOptions(channelSelect, 'email');
+      expect(channelSelect).toHaveValue('email');
+    });
+
+    it('should toggle active checkbox in edit mode', async () => {
+      const initial = {
+        id: 'test-id-3',
+        slug: 'test-template',
+        label: 'Test Template',
+        channel: 'sms' as const,
+        category: 'Test Category',
+        body: 'Hello {{customer.name}}',
+        variables: ['customer.name'],
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      };
+
+      render(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} />);
+
+      const activeCheckbox = screen.getByLabelText('Active');
+      expect(activeCheckbox).toBeChecked();
+
+      await user.click(activeCheckbox);
+      expect(activeCheckbox).not.toBeChecked();
+    });
+
+    it('should close modal when close button is clicked', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const closeButton = screen.getByLabelText('Close');
+      await user.click(closeButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should close modal when cancel button is clicked', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      await user.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Template Variables and Preview', () => {
+    it('should display extracted variables', () => {
+      (extractTemplateVariables as any).mockReturnValue(['customer.name', 'vehicle.make', 'appointment.date']);
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      expect(screen.getByText('Extracted Variables')).toBeInTheDocument();
+      expect(screen.getByText('customer.name')).toBeInTheDocument();
+      expect(screen.getByText('vehicle.make')).toBeInTheDocument();
+      expect(screen.getByText('appointment.date')).toBeInTheDocument();
+    });
+
+    it('should not show variables section when no variables found', () => {
+      (extractTemplateVariables as any).mockReturnValue([]);
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      expect(screen.queryByText('Extracted Variables')).not.toBeInTheDocument();
+    });
+
+    it('should show character and variable count', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const bodyInput = screen.getByLabelText(/body/i);
+      await user.clear(bodyInput);
+      // Use fireEvent.change for complex text with special characters
+      fireEvent.change(bodyInput, { target: { value: 'Hello {{customer.name}}' } });
+
+      expect(screen.getByText(/\d+ chars/)).toBeInTheDocument();
+      expect(screen.getByText(/\d+ vars/)).toBeInTheDocument();
+    });
+
+    it('should show preview section', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      expect(screen.getByText('Preview (raw)')).toBeInTheDocument();
+      expect(screen.getByText('(Empty)')).toBeInTheDocument();
+
+      const bodyInput = screen.getByLabelText(/body/i);
+      await user.clear(bodyInput);
+      await user.type(bodyInput, 'Test preview content');
+
+      // Wait for the preview to update - the preview should appear in the component
+      await waitFor(() => {
+        // Find the specific preview div by its class combination
+        const previewDiv = document.querySelector('.whitespace-pre-wrap.text-xs.text-gray-800');
+        expect(previewDiv).toHaveTextContent('Test preview content');
+      });
+    });
+  });
+
+  describe('Form Validation', () => {
+    it('should validate required slug in create mode', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('template-form-error')).toHaveTextContent('Slug is required');
+      expect(createMessageTemplate).not.toHaveBeenCalled();
+    });
+
+    it('should validate slug format in create mode', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      await user.type(slugInput, 'Invalid Slug!');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('template-form-error')).toHaveTextContent('Slug must be lowercase alphanumeric, underscore or dash');
+    });
+
+    it('should validate required label', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      await user.type(slugInput, 'valid_slug');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('template-form-error')).toHaveTextContent('Label is required');
+    });
+
+    it('should validate required body', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      const labelInput = screen.getByLabelText(/label/i);
+
+      await user.type(slugInput, 'valid_slug');
+      await user.type(labelInput, 'Valid Label');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('template-form-error')).toHaveTextContent('Body is required');
+    });
+
+    it('should validate body length limit', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      const labelInput = screen.getByLabelText(/label/i);
+      const bodyInput = screen.getByLabelText(/body/i);
+
+      await user.type(slugInput, 'valid_slug');
+      await user.type(labelInput, 'Valid Label');
+
+      // Use paste to set a long value more efficiently
+      const longText = 'x'.repeat(5001);
+      fireEvent.change(bodyInput, { target: { value: longText } });
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('template-form-error')).toHaveTextContent('Body too long (max 5000)');
+    });
+
+    it('should validate channel value', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      const labelInput = screen.getByLabelText(/label/i);
+      const bodyInput = screen.getByLabelText(/body/i);
+
+      await user.type(slugInput, 'valid_slug');
+      await user.type(labelInput, 'Valid Label');
+      await user.type(bodyInput, 'Valid body');
+
+      // This test validates that channel validation exists
+      // In actual UI, invalid values aren't possible due to select constraints
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      // With valid inputs, no error should appear
+      expect(screen.queryByTestId('template-form-error')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('API Integration - Create Mode', () => {
+    it('should successfully create a template', async () => {
+      const mockTemplate = {
+        id: 'new-template-id',
+        slug: 'test_template',
+        label: 'Test Template',
+        channel: 'sms' as const,
+        category: 'Test',
+        body: 'Hello {{customer.name}}',
+        variables: ['customer.name'],
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      };
+
+      (createMessageTemplate as any).mockResolvedValue(mockTemplate);
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      const labelInput = screen.getByLabelText(/label/i);
+      const categoryInput = screen.getByLabelText(/category/i);
+      const bodyInput = screen.getByLabelText(/body/i);
+
+      await user.clear(slugInput);
+      await user.clear(labelInput);
+      await user.clear(categoryInput);
+      await user.clear(bodyInput);
+
+      await user.type(slugInput, 'test_template');
+      await user.type(labelInput, 'Test Template');
+      await user.type(categoryInput, 'Test');
+      // Use fireEvent.change for complex text with special characters
+      fireEvent.change(bodyInput, { target: { value: 'Hello {{customer.name}}' } });
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(createMessageTemplate).toHaveBeenCalledWith({
+          slug: 'test_template',
+          label: 'Test Template',
+          channel: 'sms',
+          category: 'Test',
+          body: 'Hello {{customer.name}}',
+        });
+      });
+
+      expect(mockOnSaved).toHaveBeenCalledWith(mockTemplate);
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('should handle create API error', async () => {
+      (createMessageTemplate as any).mockRejectedValue(new Error('API Error'));
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      await user.type(screen.getByLabelText(/slug/i), 'test_template');
+      await user.type(screen.getByLabelText(/label/i), 'Test Template');
+      await user.type(screen.getByLabelText(/body/i), 'Hello world');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('template-form-error')).toHaveTextContent('API Error');
+      });
+
+      expect(mockOnSaved).not.toHaveBeenCalled();
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('should show saving state during create', async () => {
+      (createMessageTemplate as any).mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      await user.type(screen.getByLabelText(/slug/i), 'test_template');
+      await user.type(screen.getByLabelText(/label/i), 'Test Template');
+      await user.type(screen.getByLabelText(/body/i), 'Hello world');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByText('Saving...')).toBeInTheDocument();
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  describe('API Integration - Edit Mode', () => {
+    const initial = {
+      id: 'existing-id',
+      slug: 'existing_template',
+      label: 'Existing Template',
+      channel: 'email' as const,
+      category: 'Existing',
+      body: 'Hello {{customer.name}}',
+      variables: ['customer.name'],
+      is_active: true,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z'
+    };
+
+    it('should successfully update a template', async () => {
+      const mockUpdatedTemplate = { ...initial, label: 'Updated Template' };
+      (updateMessageTemplate as any).mockResolvedValue(mockUpdatedTemplate);
+
+      render(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} />);
+
+      const labelInput = screen.getByLabelText(/label/i);
+      await user.clear(labelInput);
+      await user.type(labelInput, 'Updated Template');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(updateMessageTemplate).toHaveBeenCalledWith('existing_template', {
+          label: 'Updated Template',
+          channel: 'email',
+          category: 'Existing',
+          body: 'Hello {{customer.name}}',
+          is_active: true,
+        });
+      });
+
+      expect(mockOnSaved).toHaveBeenCalledWith(mockUpdatedTemplate);
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('should handle missing initial template in edit mode', async () => {
+      render(<TemplateFormModal {...defaultProps} mode="edit" initial={null} />);
+
+      // When initial is null in edit mode, it should show empty form
+      const labelInput = screen.getByLabelText(/label/i) as HTMLInputElement;
+      const categoryInput = screen.getByLabelText(/category/i) as HTMLInputElement;
+      const bodyInput = screen.getByLabelText(/body/i) as HTMLTextAreaElement;
+
+      expect(labelInput.value).toBe('');
+      expect(categoryInput.value).toBe('');
+      expect(bodyInput.value).toBe('');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      // Should show validation error for required label field
+      await waitFor(() => {
+        expect(screen.getByTestId('template-form-error')).toHaveTextContent('Label is required');
+      });
+    });
+
+    it('should handle update API error', async () => {
+      (updateMessageTemplate as any).mockRejectedValue(new Error('Update failed'));
+
+      render(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} />);
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('template-form-error')).toHaveTextContent('Update failed');
+      });
+    });
+  });
+
+  describe('State Management and Effects', () => {
+    it('should reset form when modal opens in create mode', () => {
+      const { rerender } = render(<TemplateFormModal {...defaultProps} open={false} />);
+
+      rerender(<TemplateFormModal {...defaultProps} open={true} />);
+
+      expect(screen.getByLabelText(/slug/i)).toHaveValue('');
+      expect(screen.getByLabelText(/label/i)).toHaveValue('');
+    });
+
+    it('should populate form when modal opens in edit mode', () => {
+      const initial = {
+        id: 'test-populate-id',
+        slug: 'test_template',
+        label: 'Test Template',
+        channel: 'sms' as const,
+        category: 'Test',
+        body: 'Hello world',
+        variables: [],
+        is_active: false,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      };
+
+      const { rerender } = render(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} open={false} />);
+
+      rerender(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} open={true} />);
+
+      expect(screen.getByDisplayValue('Test Template')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Test')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Hello world')).toBeInTheDocument();
+      expect(screen.getByLabelText('Active')).not.toBeChecked();
+    });
+
+    it('should clear errors when modal opens', async () => {
+      const { rerender } = render(<TemplateFormModal {...defaultProps} />);
+
+      // Trigger an error
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+      expect(screen.getByTestId('template-form-error')).toBeInTheDocument();
+
+      // Close and reopen modal
+      rerender(<TemplateFormModal {...defaultProps} open={false} />);
+      rerender(<TemplateFormModal {...defaultProps} open={true} />);
+
+      expect(screen.queryByTestId('template-form-error')).not.toBeInTheDocument();
+    });
+
+    it('should handle category as undefined when empty', async () => {
+      (createMessageTemplate as any).mockResolvedValue({});
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      await user.type(screen.getByLabelText(/slug/i), 'test_template');
+      await user.type(screen.getByLabelText(/label/i), 'Test Template');
+      await user.type(screen.getByLabelText(/body/i), 'Hello world');
+      // Leave category empty
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(createMessageTemplate).toHaveBeenCalledWith({
+          slug: 'test_template',
+          label: 'Test Template',
+          channel: 'sms',
+          category: undefined,
+          body: 'Hello world',
+        });
+      });
+    });
+  });
+
+  describe('Accessibility and UX', () => {
+    it('should have proper ARIA attributes', () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+      const closeButton = screen.getByLabelText('Close');
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it('should prevent form submission on Enter in input fields', () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const form = screen.getByRole('dialog').querySelector('form');
+      expect(form).toHaveAttribute('noValidate');
+    });
+
+    it('should show required field indicators', () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      expect(screen.getAllByText('*')).toHaveLength(4); // Slug, Label, Channel, Body are required
+      expect(screen.getByText('Fields marked * required')).toBeInTheDocument();
+    });
+
+    it('should handle form submission via Enter key', async () => {
+      (createMessageTemplate as any).mockResolvedValue({});
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      const slugInput = screen.getByLabelText(/slug/i);
+      const labelInput = screen.getByLabelText(/label/i);
+      const bodyInput = screen.getByLabelText(/body/i);
+
+      await user.clear(slugInput);
+      await user.clear(labelInput);
+      await user.clear(bodyInput);
+
+      await user.type(slugInput, 'test_template');
+      await user.type(labelInput, 'Test Template');
+      await user.type(bodyInput, 'Hello world');
+
+      // Submit form by clicking submit button instead of Enter
+      // (Since form has noValidate, Enter doesn't trigger submission)
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(createMessageTemplate).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    it('should handle API errors without error message', async () => {
+      (createMessageTemplate as any).mockRejectedValue({});
+
+      render(<TemplateFormModal {...defaultProps} />);
+
+      await user.type(screen.getByLabelText(/slug/i), 'test_template');
+      await user.type(screen.getByLabelText(/label/i), 'Test Template');
+      await user.type(screen.getByLabelText(/body/i), 'Hello world');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('template-form-error')).toHaveTextContent('Failed to save');
+      });
+    });
+
+    it('should handle initial template with missing category', () => {
+      const initial = {
+        id: 'test-no-category-id',
+        slug: 'test_template',
+        label: 'Test Template',
+        channel: 'sms' as const,
+        body: 'Hello world',
+        variables: [],
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      };
+
+      render(<TemplateFormModal {...defaultProps} mode="edit" initial={initial} />);
+
+      expect(screen.getByLabelText(/category/i)).toHaveValue('');
+    });
+
+    it('should handle form field edge cases', async () => {
+      render(<TemplateFormModal {...defaultProps} />);
+
+      // Test with whitespace-only inputs
+      await user.type(screen.getByLabelText(/slug/i), '   ');
+      await user.type(screen.getByLabelText(/label/i), '   ');
+      await user.type(screen.getByLabelText(/body/i), '   ');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('template-form-error')).toHaveTextContent('Slug is required');
+    });
+  });
+});


### PR DESCRIPTION
Adds targeted component test suites for key modal & drawer surfaces.

Included test files:
- AppointmentDetailModal.real.test.tsx
- AppointmentDrawer.invoice.test.tsx
- AppointmentDrawer.overview.test.tsx
- AppointmentDrawer.richerror.test.tsx
- AppointmentDrawer.services.test.tsx
- AppointmentDrawer.states.test.tsx
- TemplateFormModal.comprehensive.test.tsx

Not included (deferred): AppointmentFormModal unstable variants (.skip) to avoid PR scope creep; will revisit after dashboard coverage or as a follow-up hardening task.

Rationale:
This is PR #3 in the decomposed sequence (after stabilization & utility/service coverage). Focuses solely on modal & drawer UI state logic to boost realistic interaction coverage without bringing in Dashboard suites yet.

Next:
PR #4 will introduce Dashboard coverage suites once this merges. After all four PRs land, thresholds will be restored toward 80%.